### PR TITLE
migration to starling 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ So in short, this extension has less features, but is compatible with `flatten`,
 
 If all you need are Lines, Circles and custom Polygons, then do not look any further.
 
+Note** v2 utilizes the Starling 2 library and flatten has been removed.
+
 Shapes
 ------
 
@@ -28,7 +30,11 @@ Shapes
 A Poly4 represents an abitrary 4-sided polygon with a uniform color or a color gradient.
 
 ```as3
+v1
 Poly4(p1:Point, p2:Point, p3:Point, p4:Point, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
+
+v2
+Poly4(p1:Point, p2:Point, p3:Point, p4:Point, color:uint=0xffffff)
 ```
 
 It inherits directly from starling.display.Quad, so all fancy coloring options of Quads can be used with Poly4.
@@ -41,7 +47,11 @@ A Ring represents a ring (what else?), see [this image](http://sugabetic.files.w
 
 constructor:
 ```as3
+v1
 Ring(innerRadius:Number, outerRadius:Number, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
+
+v2
+Ring(innerRadius:Number, outerRadius:Number, color:uint=0xffffff)
 ```
 
 It's built using a set of polygons. Number of vertices is relative to the outer radius.
@@ -54,7 +64,11 @@ A Disk is like a ring but without a hole in the middle.
 
 constructor:
 ```as3
+v1
 Disk(radius:Number, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
+
+v2
+Disk(radius:Number, color:uint=0xffffff)
 ```
 
 It's actually a ring with innerRadius set to 0.
@@ -67,7 +81,11 @@ A Line represents a segment with a thickness and uniform color or a color gradie
 
 constructor:
 ```as3
-Line(from:Point, to:Point, thickness:Number, color:uint, premultipliedAlpha:Boolean = true) {
+v1
+Line(from:Point, to:Point, thickness:Number, color:uint, premultipliedAlpha:Boolean = true)
+
+v2
+Line(from:Point, to:Point, thickness:Number, color:uint)
 ```
 
 It inherit from the Poly4 class which means you can setup per-vertex color.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Shapes
 A Poly4 represents an abitrary 4-sided polygon with a uniform color or a color gradient.
 
 ```as3
-v1
-Poly4(p1:Point, p2:Point, p3:Point, p4:Point, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
-
-v2
 Poly4(p1:Point, p2:Point, p3:Point, p4:Point, color:uint=0xffffff)
 ```
 
@@ -48,10 +44,6 @@ A Ring represents a ring (what else?), see [this image](http://sugabetic.files.w
 
 constructor:
 ```as3
-v1
-Ring(innerRadius:Number, outerRadius:Number, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
-
-v2
 Ring(innerRadius:Number, outerRadius:Number, color:uint=0xffffff)
 ```
 
@@ -65,10 +57,6 @@ A Disk is like a ring but without a hole in the middle.
 
 constructor:
 ```as3
-v1
-Disk(radius:Number, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
-
-v2
 Disk(radius:Number, color:uint=0xffffff)
 ```
 
@@ -82,10 +70,6 @@ A Line represents a segment with a thickness and uniform color or a color gradie
 
 constructor:
 ```as3
-v1
-Line(from:Point, to:Point, thickness:Number, color:uint, premultipliedAlpha:Boolean = true)
-
-v2
 Line(from:Point, to:Point, thickness:Number, color:uint)
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ in poor performances, especially if you have complex static objects that could h
 
 So in short, this extension has less features, but is compatible with `flatten`, which will help you write more efficient code.
 
+Note** v2 `flatten` has been removed by the Starling 2 library
+
 If all you need are Lines, Circles and custom Polygons, then do not look any further.
 
-Note** v2 utilizes the Starling 2 library and flatten has been removed.
 
 Shapes
 ------

--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ Why?
 
 Why another extension, when there's already the [Starling Graphics Extension](https://github.com/StarlingGraphics/Starling-Extension-Graphics)?
 
-Well, one draw-back of the Graphics extension is that it doesn't allow to `flatten` your sprites. Which will result
-in poor performances, especially if you have complex static objects that could have been pre-rendered.
+The original functionality of these classes was to avoid the draw-back of the Graphics extension not allowing you to `flatten` your sprites. Which resulted in poor performances, especially if you have complex static objects that could have been pre-rendered.
 
-So in short, this extension has less features, but is compatible with `flatten`, which will help you write more efficient code.
-
-Note** v2 `flatten` has been removed by the Starling 2 library
+In Starling 2 `flatten` has been removed. Starling developers have noted the `flatten` feature might come back in the future.
 
 If all you need are Lines, Circles and custom Polygons, then do not look any further.
 

--- a/src/starling/display/Disk.as
+++ b/src/starling/display/Disk.as
@@ -12,9 +12,9 @@ package starling.display
     /** A Disk represents a circle filled with a uniform color. */
     public class Disk extends Ring
     {
-        public function Disk(radius:Number, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
+        public function Disk(radius:Number, color:uint=0xffffff)
         {
-            super(0, radius, color, premultipliedAlpha);
+            super(0, radius, color);
         }
     }
 }

--- a/src/starling/display/Line.as
+++ b/src/starling/display/Line.as
@@ -21,7 +21,7 @@ package starling.display
      *  @see Poly4
      */
     public class Line extends Poly4 {
-        public function Line(from:Point, to:Point, thickness:Number, color:uint, premultipliedAlpha:Boolean = true) {
+        public function Line(from:Point, to:Point, thickness:Number, color:uint) {
             var dx:Number = to.x - from.x;
             var dy:Number = to.y - from.y;
             var l:Number = Math.sqrt(dx*dx + dy*dy);
@@ -45,7 +45,7 @@ package starling.display
             p4.offset(-v.x * halfT, -v.y * halfT);
             p4.offset(u.x * halfT, u.y * halfT);
 
-            super(p1, p2, p3, p4, color, premultipliedAlpha);
+            super(p1, p2, p3, p4, color);
         }
     }
 }

--- a/src/starling/display/Poly4.as
+++ b/src/starling/display/Poly4.as
@@ -15,8 +15,6 @@ package starling.display
     import flash.geom.Rectangle;
     import flash.geom.Vector3D;
 
-    import starling.core.RenderSupport;
-    import starling.utils.VertexData;
     import starling.display.Quad;
 
     /** A Poly4 represents an abitrary quad with a uniform color or a color gradient.
@@ -39,18 +37,17 @@ package starling.display
     {
         private var _lowerRight:Point;
 
-        public function Poly4(p1:Point, p2:Point, p3:Point, p4:Point, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
+        public function Poly4(p1:Point, p2:Point, p3:Point, p4:Point, color:uint=0xffffff)
         {
             var xmin:Number = Math.min(p1.x,p2.x,p3.x,p4.x);
             var ymin:Number = Math.min(p1.y,p2.y,p3.y,p4.y);
             var xmax:Number = Math.max(p1.x,p2.x,p3.x,p4.x);
             var ymax:Number = Math.max(p1.y,p2.y,p3.y,p4.y);
-            super(xmax-xmin,ymax-ymin,color,premultipliedAlpha);
-            mVertexData.setPosition(0, p1.x - xmin, p1.y - ymin);
-            mVertexData.setPosition(1, p2.x - xmin, p2.y - ymin);
-            mVertexData.setPosition(2, p3.x - xmin, p3.y - ymin);
-            mVertexData.setPosition(3, p4.x - xmin, p4.y - ymin);
-            onVertexDataChanged();
+            super(xmax-xmin,ymax-ymin,color);
+            vertexData.setPoint(0, 'position', p1.x - xmin, p1.y - ymin);
+            vertexData.setPoint(1, 'position', p2.x - xmin, p2.y - ymin);
+            vertexData.setPoint(2, 'position', p3.x - xmin, p3.y - ymin);
+            vertexData.setPoint(3, 'position', p4.x - xmin, p4.y - ymin);
             x = xmin;
             y = ymin;
             _lowerRight = new Point(xmax - xmin, ymax - ymin);

--- a/src/starling/display/Ring.as
+++ b/src/starling/display/Ring.as
@@ -15,8 +15,6 @@ package starling.display
     import flash.geom.Rectangle;
     import flash.geom.Vector3D;
 
-    import starling.core.RenderSupport;
-    import starling.utils.VertexData;
     import starling.display.Sprite;
     import starling.display.Quad;
 
@@ -31,7 +29,7 @@ package starling.display
         public function get innerRadius():Number { return _innerRadius; }
         public function get outerRadius():Number { return _outerRadius; }
 
-        public function Ring(innerRadius:Number, outerRadius:Number, color:uint=0xffffff, premultipliedAlpha:Boolean=true)
+        public function Ring(innerRadius:Number, outerRadius:Number, color:uint=0xffffff)
         {
             _polygons = new Vector.<Poly4>;
             _innerRadius = innerRadius;
@@ -58,7 +56,8 @@ package starling.display
                 p0.y = outerRadius + sa0 * outerRadius;
                 p1.x = outerRadius + ca1 * outerRadius;
                 p1.y = outerRadius + sa1 * outerRadius;
-                var q:Poly4 = new Poly4(c0, p0, c1, p1, color, premultipliedAlpha);
+                var q:Poly4 = new Poly4(c0, p0, c1, p1, color);
+                    q.pixelSnapping = false;
                 _polygons.push(q);
                 addChild(q);
             }
@@ -70,9 +69,9 @@ package starling.display
             }
         }
 
-        public override function hitTest(localPoint:Point, forTouch:Boolean = false):DisplayObject {
+        public override function hitTest(localPoint:Point):DisplayObject {
             // on a touch test, invisible or untouchable objects cause the test to fail
-            if (forTouch && (!visible || !touchable)) return null;
+            if (!visible || !touchable) return null;
             var vx:Number = localPoint.x - _outerRadius;
             var vy:Number = localPoint.y - _outerRadius;
             var l2:Number = vx*vx + vy*vy;


### PR DESCRIPTION
Update to Starling 2.0
Because these changes break backwards compatibility I have created a v2.0.0 tag. If you need support for the older version of Starling Framework use the v1.0.0 tag.
